### PR TITLE
Test FlexReview team filtering

### DIFF
--- a/.aviator/OWNERS
+++ b/.aviator/OWNERS
@@ -1,2 +1,2 @@
-**/**.py      @aviator-ss-testing/ss-be
+**/**.py      @aviator-ss-testing/ss-be @aviator-ss-testing/ss-fe @simaviator @simsinght
 **/**.txt     @aviator-ss-testing/ss-fe

--- a/backend_service.py
+++ b/backend_service.py
@@ -1,0 +1,25 @@
+"""
+Backend service for testing FlexReview team filtering.
+This file should trigger @aviator-ss-testing/ss-be team.
+"""
+
+def process_data(data):
+    """Process incoming data"""
+    return {"status": "processed", "data": data}
+
+
+def validate_input(input_data):
+    """Validate input parameters"""
+    if not input_data:
+        return False
+    return True
+
+
+class BackendService:
+    def __init__(self):
+        self.initialized = True
+    
+    def handle_request(self, request):
+        if self.validate_input(request):
+            return self.process_data(request)
+        return {"error": "Invalid input"}

--- a/frontend_config.txt
+++ b/frontend_config.txt
@@ -1,0 +1,17 @@
+Frontend Configuration File
+This file should trigger @aviator-ss-testing/ss-fe team.
+
+API_BASE_URL=https://api.example.com
+THEME=dark
+ENABLE_ANALYTICS=true
+CACHE_TIMEOUT=300
+MAX_RETRY_ATTEMPTS=3
+
+# Feature flags
+ENABLE_NEW_UI=false
+ENABLE_DARK_MODE=true
+SHOW_BETA_FEATURES=false
+
+# Debugging
+DEBUG_MODE=false
+LOG_LEVEL=info


### PR DESCRIPTION
This PR modifies both:
- backend_service.py (should assign @aviator-ss-testing/ss-be)
- frontend_config.txt (should assign @aviator-ss-testing/ss-fe)

Expected behavior with team filtering:
- ss-be channel: Only see backend reviewers (simsinght, simaviator)
- ss-fe channel: Only see frontend reviewers (tulioz, simsinght)
- simsinght appears in both channels since they're on both teams