### PR TITLE
Add Python Modules with Tests: Add collections_utils module

### DIFF
--- a/collections_utils.py
+++ b/collections_utils.py
@@ -1,0 +1,40 @@
+"""List and dict helper functions using only the Python standard library."""
+
+from collections import OrderedDict
+from typing import Callable
+
+
+def flatten(nested: list) -> list:
+    result = []
+    for item in nested:
+        if isinstance(item, list):
+            result.extend(flatten(item))
+        else:
+            result.append(item)
+    return result
+
+
+def chunk(lst: list, size: int) -> list[list]:
+    if size < 1:
+        raise ValueError("size must be at least 1")
+    return [lst[i:i + size] for i in range(0, len(lst), size)]
+
+
+def group_by(lst: list, key: Callable) -> dict:
+    groups: dict = OrderedDict()
+    for item in lst:
+        k = key(item)
+        if k not in groups:
+            groups[k] = []
+        groups[k].append(item)
+    return groups
+
+
+def dedupe_stable(lst: list) -> list:
+    seen: set = set()
+    result = []
+    for item in lst:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result

--- a/test_collections_utils.py
+++ b/test_collections_utils.py
@@ -1,0 +1,142 @@
+"""Tests for the collections_utils module."""
+
+import pytest
+from collections_utils import flatten, chunk, group_by, dedupe_stable
+
+
+# --- flatten ---
+
+def test_flatten_empty():
+    assert flatten([]) == []
+
+
+def test_flatten_already_flat():
+    assert flatten([1, 2, 3]) == [1, 2, 3]
+
+
+def test_flatten_single_element():
+    assert flatten([42]) == [42]
+
+
+def test_flatten_one_level():
+    assert flatten([[1, 2], [3, 4]]) == [1, 2, 3, 4]
+
+
+def test_flatten_deeply_nested():
+    assert flatten([1, [2, [3, [4, [5]]]]]) == [1, 2, 3, 4, 5]
+
+
+def test_flatten_mixed_depth():
+    assert flatten([1, [2, 3], [4, [5, 6]]]) == [1, 2, 3, 4, 5, 6]
+
+
+def test_flatten_nested_empty_lists():
+    assert flatten([[], [1], [[], 2]]) == [1, 2]
+
+
+def test_flatten_strings_not_expanded():
+    assert flatten(["ab", ["cd", "ef"]]) == ["ab", "cd", "ef"]
+
+
+# --- chunk ---
+
+def test_chunk_empty():
+    assert chunk([], 3) == []
+
+
+def test_chunk_exact_division():
+    assert chunk([1, 2, 3, 4], 2) == [[1, 2], [3, 4]]
+
+
+def test_chunk_last_chunk_shorter():
+    assert chunk([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
+
+
+def test_chunk_size_one():
+    assert chunk([1, 2, 3], 1) == [[1], [2], [3]]
+
+
+def test_chunk_size_larger_than_list():
+    assert chunk([1, 2], 10) == [[1, 2]]
+
+
+def test_chunk_single_element():
+    assert chunk([99], 3) == [[99]]
+
+
+def test_chunk_invalid_size_zero():
+    with pytest.raises(ValueError):
+        chunk([1, 2, 3], 0)
+
+
+def test_chunk_invalid_size_negative():
+    with pytest.raises(ValueError):
+        chunk([1, 2, 3], -1)
+
+
+# --- group_by ---
+
+def test_group_by_empty():
+    assert group_by([], lambda x: x) == {}
+
+
+def test_group_by_single_element():
+    assert group_by([1], lambda x: x) == {1: [1]}
+
+
+def test_group_by_even_odd():
+    result = group_by([1, 2, 3, 4, 5], lambda x: x % 2)
+    assert result[1] == [1, 3, 5]
+    assert result[0] == [2, 4]
+
+
+def test_group_by_preserves_insertion_order():
+    result = group_by(["banana", "apple", "avocado", "blueberry"], lambda s: s[0])
+    assert list(result["b"]) == ["banana", "blueberry"]
+    assert list(result["a"]) == ["apple", "avocado"]
+
+
+def test_group_by_all_same_key():
+    assert group_by([1, 2, 3], lambda x: "all") == {"all": [1, 2, 3]}
+
+
+def test_group_by_all_unique_keys():
+    result = group_by([1, 2, 3], lambda x: x)
+    assert result == {1: [1], 2: [2], 3: [3]}
+
+
+def test_group_by_dicts():
+    items = [{"type": "a", "val": 1}, {"type": "b", "val": 2}, {"type": "a", "val": 3}]
+    result = group_by(items, lambda x: x["type"])
+    assert len(result["a"]) == 2
+    assert result["b"][0]["val"] == 2
+
+
+# --- dedupe_stable ---
+
+def test_dedupe_stable_empty():
+    assert dedupe_stable([]) == []
+
+
+def test_dedupe_stable_no_duplicates():
+    assert dedupe_stable([1, 2, 3]) == [1, 2, 3]
+
+
+def test_dedupe_stable_single_element():
+    assert dedupe_stable([7]) == [7]
+
+
+def test_dedupe_stable_preserves_order():
+    assert dedupe_stable([3, 1, 2, 1, 3]) == [3, 1, 2]
+
+
+def test_dedupe_stable_all_same():
+    assert dedupe_stable([5, 5, 5, 5]) == [5]
+
+
+def test_dedupe_stable_strings():
+    assert dedupe_stable(["a", "b", "a", "c", "b"]) == ["a", "b", "c"]
+
+
+def test_dedupe_stable_mixed_types():
+    assert dedupe_stable([1, "1", 1, "1"]) == [1, "1"]


### PR DESCRIPTION
This PR was created automatically by Aviator Runbooks.
**Runbook URL**: http://127.0.0.1:5000/r/114
**Executed by**: @simsinght

<details>
<summary>💡 Revise with Runbooks</summary>

Use `/aviator revise` to address the feedback provided on this PR:

**As a PR comment:**

- `/aviator revise` - Process all unresolved review comments on the PR
- `/aviator revise [instructions]` - Process any unresolved comments and handle additional instructions.

**As a review comment:**

- Reply with `/aviator revise [instructions]` to an existing review comment to address that specific thread
- Post `/aviator revise [instructions]` as a review comment to have Runbooks revise that code section based on given instructions.

[Read the complete guide with examples](https://docs.aviator.co/runbooks/how-to-guides/providing-feedback)

</details>

<!-- av:steps:begin -->
## Steps

**Included in this PR**
- 3.1 Create collections_utils.py and test_collections_utils.py

<details>
<summary>View all Runbook steps (3 of 4 complete)</summary>

1. **Add stats module**
   - 1.1 Create stats.py and test_stats.py [#252](https://github.com/aviator-ss-testing/ss-actions-testing/pull/252)
2. **Add strings module**
   - 2.1 Create strings.py and test_strings.py [#253](https://github.com/aviator-ss-testing/ss-actions-testing/pull/253)
3. **Add collections_utils module**
   - 3.1 Create collections_utils.py and test_collections_utils.py 👈
4. **Update CI**
   - 4.1 Update test workflow to discover all test files

</details>
<!-- av:steps:end -->

<!-- av pr metadata
This comment helps Aviator manage stacked PRs. Please don't delete it.
```
{"parent": "av/rb-114-2-1227", "parentHead": "9c743242bd8624b283405bce9db2e76c3d26d82e", "parentPull": 253, "trunk": "main"}
```
-->